### PR TITLE
Hide labels that user does not have permission to add when create and edit

### DIFF
--- a/src/gigs-board/components/posts/List.jsx
+++ b/src/gigs-board/components/posts/List.jsx
@@ -120,6 +120,7 @@ function getPostsByAuthor() {
   if (postIds) {
     postIds.reverse();
   }
+  return postIds;
 }
 
 function intersectPostsWithLabel(postIds) {
@@ -424,8 +425,10 @@ return (
       </InfiniteScroll>
     ) : (
       <p class="text-secondary">
-        No posts {props.searchResult ? "matches search" : ""} in
-        {getPeriodText(state.period).toLowerCase()}
+        No posts {props.searchResult ? "matches search" : ""}
+        {props.recency == "hot"
+          ? " in " + getPeriodText(state.period).toLowerCase()
+          : ""}
       </p>
     )}
   </>

--- a/src/gigs-board/components/posts/PostEditor.jsx
+++ b/src/gigs-board/components/posts/PostEditor.jsx
@@ -187,6 +187,25 @@ const normalizeLabel = (label) =>
     .toLowerCase()
     .trim("-");
 
+const checkLabel = (label) => {
+  Near.asyncView(nearDevGovGigsContractAccountId, "is_allowed_to_use_labels", {
+    editor: context.accountId,
+    labels: [label],
+  }).then((allowed) => {
+    if (allowed) {
+      State.update({ warning: "" });
+    } else {
+      State.update({
+        warning:
+          'The label "' +
+          label +
+          '" is protected and can only be added by moderators',
+      });
+      return;
+    }
+  });
+};
+
 const setLabels = (labels) => {
   labels = labels.map((o) => {
     o.name = normalizeLabel(o.name);
@@ -209,7 +228,12 @@ const setLabels = (labels) => {
         });
         State.update({ labels, labelStrings });
       } else {
-        State.update({ warning: "No permission to remove " + removed });
+        State.update({
+          warning:
+            'The label "' +
+            removed +
+            '" is protected and can only be updated by moderators',
+        });
         return;
       }
     });
@@ -235,6 +259,7 @@ const labelEditor = (
     <Typeahead
       multiple
       labelKey="name"
+      onInputChange={checkLabel}
       onChange={setLabels}
       options={existingLabels}
       placeholder="near.social, widget, NEP, standard, protocol, tool"

--- a/src/gigs-board/components/posts/PostEditor.jsx
+++ b/src/gigs-board/components/posts/PostEditor.jsx
@@ -223,9 +223,7 @@ const setLabels = (labels) => {
       { editor: context.accountId, labels: [removed] }
     ).then((allowed) => {
       if (allowed) {
-        let labelStrings = labels.map((o) => {
-          return o.name;
-        });
+        let labelStrings = labels.map(({ name }) => name);
         State.update({ labels, labelStrings });
       } else {
         State.update({


### PR DESCRIPTION
Resolves https://github.com/near/devgigsboard-widgets/issues/10.

After this PR, labels that user does not have permission to add are hidden, when create and edit a post. Preview: https://near.social/#/bo.near/widget/gigs-board.pages.Feed?nearDevGovGigsContractAccountId=devgovgigs.near

And there is a warning if user without permission is trying to add such label:
<img width="1219" alt="image" src="https://user-images.githubusercontent.com/13259400/233518250-e3c67f49-6854-4b25-8fee-d9a0b2ade250.png">


Also, when user try to remove a label that he doesn't have a permission, it will now fail on UI and it will not be removed:

<img width="1166" alt="image" src="https://user-images.githubusercontent.com/13259400/233518336-e499c9d2-cca3-46d2-b1a9-55f3b59f34d7.png">


Previous to this PR it would not fail until submit the transaction:
<img width="1267" alt="Screenshot 2023-04-20 at 3 08 14 PM" src="https://user-images.githubusercontent.com/13259400/233303169-85722cd3-e6ea-4007-b45e-88b2b2dc1986.png">

Note that due to current near social viewer's limitation, it's not possible to add a lock icon to the protected labels like below, because related react-bootstrap-typeahead APIs are not exported:

<img width="627" alt="Screenshot 2023-04-20 at 3 29 01 PM" src="https://user-images.githubusercontent.com/13259400/233303426-7f294155-f6d7-41dd-8a98-da01a5cc2509.png">
