### PR TITLE
Fix to showing Read More on post page #113

### DIFF
--- a/src/gigs-board/components/posts/Post.jsx
+++ b/src/gigs-board/components/posts/Post.jsx
@@ -522,8 +522,10 @@ const clampMarkdown = styled.div`
   }
 `;
 
+// Determine if located in the post page.
+const isPostPage = Number.isInteger(props.id) && props.id > 0;
 const contentArray = snapshot.description.split("\n");
-const needClamp = contentArray.length > 5;
+const needClamp = !isPostPage && contentArray.length > 5;
 
 initState({
   clamp: needClamp,


### PR DESCRIPTION
Fix to showing the description section of a post collapsed when viewing the post page.