### PR TITLE
Community latest telegram messages

### DIFF
--- a/communities.jsx
+++ b/communities.jsx
@@ -7,6 +7,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreihgxg5kwts2juldaeasveyuddkm6tcabmrat2aaq5u6uyljtyt7lu",
     title: "Zero Knowledge",
     desc: "Building a zero knowledge ecosystem on NEAR.",
+    telegram: "NearZeroKnowledge",
   },
   protocol: {
     overviewId: 412,
@@ -16,6 +17,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreicg4svzfz5nvllomsahndgm7u62za4sib4mmbygxzhpcl4htqwr4a",
     title: "Protocol",
     desc: "Supporting the ongoing innovation of the NEAR Protocol.",
+    telegram: "NEAR_Protocol_Community_Group",
   },
   tooling: {
     overviewId: 416,
@@ -25,6 +27,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiehzr7z2fhoqqmkt3z667wubccbch6sqtsnvd6msodyzpnf72cszy",
     title: "Tooling",
     desc: "Supporting the ongoing innovation of tooling.",
+    telegram: "NEAR_Tools_Community_Group",
   },
   "contract-standards": {
     overviewId: 414,
@@ -34,5 +37,6 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiaowjqxds24fwcliyriintjd4ucciprii2rdxjmxgi7f5dmzuscey",
     title: "Contract Standards",
     desc: "Coordinating the contribution to the NEAR dapp standards.",
+    telegram: "nearnft",
   },
 };

--- a/src/gigs-board/components/community/CommunityHeader.jsx
+++ b/src/gigs-board/components/community/CommunityHeader.jsx
@@ -159,6 +159,21 @@ return (
               Events
             </a>
           </li>
+          <li class="nav-item">
+            <a
+              class="nav-link"
+              className={
+                props.tab === "Telegram" ? "nav-link active" : "nav-link"
+              }
+              href={href("community.Telegram", {
+                label: props.label,
+                tab: "Telegram",
+              })}
+            >
+              <i class="bi-telegram"> </i>
+              Telegram
+            </a>
+          </li>
         </NavUnderline>
       </div>
     </Header>

--- a/src/gigs-board/components/community/FeedHeader.jsx
+++ b/src/gigs-board/components/community/FeedHeader.jsx
@@ -54,6 +54,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreihgxg5kwts2juldaeasveyuddkm6tcabmrat2aaq5u6uyljtyt7lu",
     title: "Zero Knowledge",
     desc: "Building a zero knowledge ecosystem on NEAR.",
+    telegram: "NearZeroKnowledge",
   },
   protocol: {
     overviewId: 412,
@@ -63,6 +64,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreicg4svzfz5nvllomsahndgm7u62za4sib4mmbygxzhpcl4htqwr4a",
     title: "Protocol",
     desc: "Supporting the ongoing innovation of the NEAR Protocol.",
+    telegram: "NEAR_Protocol_Community_Group",
   },
   tooling: {
     overviewId: 416,
@@ -72,6 +74,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiehzr7z2fhoqqmkt3z667wubccbch6sqtsnvd6msodyzpnf72cszy",
     title: "Tooling",
     desc: "Supporting the ongoing innovation of tooling.",
+    telegram: "NEAR_Tools_Community_Group",
   },
   "contract-standards": {
     overviewId: 414,
@@ -81,6 +84,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiaowjqxds24fwcliyriintjd4ucciprii2rdxjmxgi7f5dmzuscey",
     title: "Contract Standards",
     desc: "Coordinating the contribution to the NEAR dapp standards.",
+    telegram: "nearnft",
   },
 };
 /* END_INCLUDE: "communities.jsx" */

--- a/src/gigs-board/components/community/Layout.jsx
+++ b/src/gigs-board/components/community/Layout.jsx
@@ -54,6 +54,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreihgxg5kwts2juldaeasveyuddkm6tcabmrat2aaq5u6uyljtyt7lu",
     title: "Zero Knowledge",
     desc: "Building a zero knowledge ecosystem on NEAR.",
+    telegram: "NearZeroKnowledge",
   },
   protocol: {
     overviewId: 412,
@@ -63,6 +64,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreicg4svzfz5nvllomsahndgm7u62za4sib4mmbygxzhpcl4htqwr4a",
     title: "Protocol",
     desc: "Supporting the ongoing innovation of the NEAR Protocol.",
+    telegram: "NEAR_Protocol_Community_Group",
   },
   tooling: {
     overviewId: 416,
@@ -72,6 +74,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiehzr7z2fhoqqmkt3z667wubccbch6sqtsnvd6msodyzpnf72cszy",
     title: "Tooling",
     desc: "Supporting the ongoing innovation of tooling.",
+    telegram: "NEAR_Tools_Community_Group",
   },
   "contract-standards": {
     overviewId: 414,
@@ -81,6 +84,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiaowjqxds24fwcliyriintjd4ucciprii2rdxjmxgi7f5dmzuscey",
     title: "Contract Standards",
     desc: "Coordinating the contribution to the NEAR dapp standards.",
+    telegram: "nearnft",
   },
 };
 /* END_INCLUDE: "communities.jsx" */

--- a/src/gigs-board/pages/community/Events.jsx
+++ b/src/gigs-board/pages/community/Events.jsx
@@ -54,6 +54,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreihgxg5kwts2juldaeasveyuddkm6tcabmrat2aaq5u6uyljtyt7lu",
     title: "Zero Knowledge",
     desc: "Building a zero knowledge ecosystem on NEAR.",
+    telegram: "NearZeroKnowledge",
   },
   protocol: {
     overviewId: 412,
@@ -63,6 +64,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreicg4svzfz5nvllomsahndgm7u62za4sib4mmbygxzhpcl4htqwr4a",
     title: "Protocol",
     desc: "Supporting the ongoing innovation of the NEAR Protocol.",
+    telegram: "NEAR_Protocol_Community_Group",
   },
   tooling: {
     overviewId: 416,
@@ -72,6 +74,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiehzr7z2fhoqqmkt3z667wubccbch6sqtsnvd6msodyzpnf72cszy",
     title: "Tooling",
     desc: "Supporting the ongoing innovation of tooling.",
+    telegram: "NEAR_Tools_Community_Group",
   },
   "contract-standards": {
     overviewId: 414,
@@ -81,6 +84,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiaowjqxds24fwcliyriintjd4ucciprii2rdxjmxgi7f5dmzuscey",
     title: "Contract Standards",
     desc: "Coordinating the contribution to the NEAR dapp standards.",
+    telegram: "nearnft",
   },
 };
 /* END_INCLUDE: "communities.jsx" */

--- a/src/gigs-board/pages/community/Overview.jsx
+++ b/src/gigs-board/pages/community/Overview.jsx
@@ -54,6 +54,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreihgxg5kwts2juldaeasveyuddkm6tcabmrat2aaq5u6uyljtyt7lu",
     title: "Zero Knowledge",
     desc: "Building a zero knowledge ecosystem on NEAR.",
+    telegram: "NearZeroKnowledge",
   },
   protocol: {
     overviewId: 412,
@@ -63,6 +64,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreicg4svzfz5nvllomsahndgm7u62za4sib4mmbygxzhpcl4htqwr4a",
     title: "Protocol",
     desc: "Supporting the ongoing innovation of the NEAR Protocol.",
+    telegram: "NEAR_Protocol_Community_Group",
   },
   tooling: {
     overviewId: 416,
@@ -72,6 +74,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiehzr7z2fhoqqmkt3z667wubccbch6sqtsnvd6msodyzpnf72cszy",
     title: "Tooling",
     desc: "Supporting the ongoing innovation of tooling.",
+    telegram: "NEAR_Tools_Community_Group",
   },
   "contract-standards": {
     overviewId: 414,
@@ -81,6 +84,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiaowjqxds24fwcliyriintjd4ucciprii2rdxjmxgi7f5dmzuscey",
     title: "Contract Standards",
     desc: "Coordinating the contribution to the NEAR dapp standards.",
+    telegram: "nearnft",
   },
 };
 /* END_INCLUDE: "communities.jsx" */

--- a/src/gigs-board/pages/community/Sponsorship.jsx
+++ b/src/gigs-board/pages/community/Sponsorship.jsx
@@ -54,6 +54,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreihgxg5kwts2juldaeasveyuddkm6tcabmrat2aaq5u6uyljtyt7lu",
     title: "Zero Knowledge",
     desc: "Building a zero knowledge ecosystem on NEAR.",
+    telegram: "NearZeroKnowledge",
   },
   protocol: {
     overviewId: 412,
@@ -63,6 +64,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreicg4svzfz5nvllomsahndgm7u62za4sib4mmbygxzhpcl4htqwr4a",
     title: "Protocol",
     desc: "Supporting the ongoing innovation of the NEAR Protocol.",
+    telegram: "NEAR_Protocol_Community_Group",
   },
   tooling: {
     overviewId: 416,
@@ -72,6 +74,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiehzr7z2fhoqqmkt3z667wubccbch6sqtsnvd6msodyzpnf72cszy",
     title: "Tooling",
     desc: "Supporting the ongoing innovation of tooling.",
+    telegram: "NEAR_Tools_Community_Group",
   },
   "contract-standards": {
     overviewId: 414,
@@ -81,6 +84,7 @@ const communities = {
       "https://ipfs.near.social/ipfs/bafkreiaowjqxds24fwcliyriintjd4ucciprii2rdxjmxgi7f5dmzuscey",
     title: "Contract Standards",
     desc: "Coordinating the contribution to the NEAR dapp standards.",
+    telegram: "nearnft",
   },
 };
 /* END_INCLUDE: "communities.jsx" */

--- a/src/gigs-board/pages/community/Telegram.jsx
+++ b/src/gigs-board/pages/community/Telegram.jsx
@@ -109,7 +109,6 @@ if (groupInfo === null || !groupInfo.ok) {
 }
 
 const messageIds = groupInfo.body.messageIds;
-console.log(messageIds);
 
 const Telegram = (
   <>
@@ -127,21 +126,6 @@ const Telegram = (
         minWidth: "100%",
       }}
     ></iframe>
-    {messageIds.map((id) => {
-      return (
-        <iframe
-          id={id.toString()}
-          iframeResizer={{ log: true, heightCalculationMethod: "scroll" }}
-          src={
-            "https://cg-msg-viewer.pages.dev/message?group=" +
-            group +
-            "&id=" +
-            id
-          }
-          style={{ width: "1px", minWidth: "100%" }}
-        />
-      );
-    })}
   </>
 );
 

--- a/src/gigs-board/pages/community/Telegram.jsx
+++ b/src/gigs-board/pages/community/Telegram.jsx
@@ -101,24 +101,16 @@ const community = communities[props.label];
 
 const group = community.telegram;
 
-const groupInfo = fetch(
-  `https://j96g3uepe0.execute-api.us-east-1.amazonaws.com/groups/${group}`
-);
-if (groupInfo === null || !groupInfo.ok) {
-  return "Loading ...";
-}
-
-const messageIds = groupInfo.body.messageIds;
-
 const Telegram = (
   <div>
     <iframe
-      iframeResizer={{ log: true }}
+      iframeResizer
       src={
         "https://j96g3uepe0.execute-api.us-east-1.amazonaws.com/groups-ui/" +
         group
       }
       frameborder="0"
+      // Required by iframeResizer
       style={{
         width: "1px",
         minWidth: "100%",

--- a/src/gigs-board/pages/community/Telegram.jsx
+++ b/src/gigs-board/pages/community/Telegram.jsx
@@ -97,40 +97,48 @@ if (!props.label) {
   );
 }
 
-const label = props.label;
+const community = communities[props.label];
 
-const discussionRequiredPosts =
-  Near.view(nearDevGovGigsContractAccountId, "get_posts_by_label", {
-    label,
-  }) ?? [];
+const group = community.telegram;
 
-const Discussions = (
-  <div>
-    <div class="row mb-2">
-      <div class="col text-center">
-        <small class="text-muted">
-          Required label:
-          <a href={href("Feed", { label })} key={label}>
-            <span class="badge text-bg-primary me-1">{label}</span>
-          </a>
-        </small>
+const groupInfo = fetch(
+  `https://j96g3uepe0.execute-api.us-east-1.amazonaws.com/groups/${group}`
+);
+if (groupInfo === null || !groupInfo.ok) {
+  return "Loading ...";
+}
+
+const messageIds = groupInfo.body.messageIds;
+
+const Telegram = (
+  <div class="">
+    {messageIds.map((i) => (
+      <div class="row">
+        <div class="col">
+          <iframe
+            id={"telegram-post-" + i}
+            key={"telegram-post-" + i}
+            src={"https://t.me/" + group + "/" + i + "?embed=1&userpic=true"}
+            scrolling="no"
+            style={{
+              overflow: "hidden",
+              colorScheme: "light dark",
+              border: "medium none",
+              minWidth: "100%",
+              minHeight: "100px",
+            }}
+            width="100%"
+            height="100%"
+            frameborder="0"
+          ></iframe>
+        </div>
       </div>
-    </div>
-    {widget("components.layout.Controls", {
-      labels: discussionsRequiredLabels,
-    })}
-    <div class="row">
-      <div class="col">
-        {discussionRequiredPosts.map((postId) =>
-          widget("components.posts.Post", { id: postId }, postId)
-        )}
-      </div>
-    </div>
+    ))}
   </div>
 );
 
 return widget("components.community.Layout", {
   label: props.label,
-  tab: "Discussions",
-  children: Discussions,
+  tab: "Telegram",
+  children: Telegram,
 });

--- a/src/gigs-board/pages/community/Telegram.jsx
+++ b/src/gigs-board/pages/community/Telegram.jsx
@@ -109,10 +109,12 @@ if (groupInfo === null || !groupInfo.ok) {
 }
 
 const messageIds = groupInfo.body.messageIds;
+console.log(messageIds);
 
 const Telegram = (
   <>
     <iframe
+      iframeResizer={{ log: true, heightCalculationMethod: "scroll" }}
       src={
         "https://cg-msg-viewer.pages.dev/?group=" +
         group +
@@ -121,10 +123,25 @@ const Telegram = (
       }
       frameborder="0"
       style={{
-        width: "100%",
-        height: "100vh",
+        width: "1px",
+        minWidth: "100%",
       }}
     ></iframe>
+    {messageIds.map((id) => {
+      return (
+        <iframe
+          id={id.toString()}
+          iframeResizer={{ log: true, heightCalculationMethod: "scroll" }}
+          src={
+            "https://cg-msg-viewer.pages.dev/message?group=" +
+            group +
+            "&id=" +
+            id
+          }
+          style={{ width: "1px", minWidth: "100%" }}
+        />
+      );
+    })}
   </>
 );
 

--- a/src/gigs-board/pages/community/Telegram.jsx
+++ b/src/gigs-board/pages/community/Telegram.jsx
@@ -111,14 +111,12 @@ if (groupInfo === null || !groupInfo.ok) {
 const messageIds = groupInfo.body.messageIds;
 
 const Telegram = (
-  <>
+  <div>
     <iframe
-      iframeResizer={{ log: true, heightCalculationMethod: "scroll" }}
+      iframeResizer={{ log: true }}
       src={
-        "https://cg-msg-viewer.pages.dev/?group=" +
-        group +
-        "&messageIds=" +
-        messageIds
+        "https://j96g3uepe0.execute-api.us-east-1.amazonaws.com/groups-ui/" +
+        group
       }
       frameborder="0"
       style={{
@@ -126,7 +124,7 @@ const Telegram = (
         minWidth: "100%",
       }}
     ></iframe>
-  </>
+  </div>
 );
 
 return widget("components.community.Layout", {

--- a/src/gigs-board/pages/community/Telegram.jsx
+++ b/src/gigs-board/pages/community/Telegram.jsx
@@ -111,30 +111,21 @@ if (groupInfo === null || !groupInfo.ok) {
 const messageIds = groupInfo.body.messageIds;
 
 const Telegram = (
-  <div class="">
-    {messageIds.map((i) => (
-      <div class="row">
-        <div class="col">
-          <iframe
-            id={"telegram-post-" + i}
-            key={"telegram-post-" + i}
-            src={"https://t.me/" + group + "/" + i + "?embed=1&userpic=true"}
-            scrolling="no"
-            style={{
-              overflow: "hidden",
-              colorScheme: "light dark",
-              border: "medium none",
-              minWidth: "100%",
-              minHeight: "100px",
-            }}
-            width="100%"
-            height="100%"
-            frameborder="0"
-          ></iframe>
-        </div>
-      </div>
-    ))}
-  </div>
+  <>
+    <iframe
+      src={
+        "https://cg-msg-viewer.pages.dev/?group=" +
+        group +
+        "&messageIds=" +
+        messageIds
+      }
+      frameborder="0"
+      style={{
+        width: "100%",
+        height: "100vh",
+      }}
+    ></iframe>
+  </>
 );
 
 return widget("components.community.Layout", {


### PR DESCRIPTION
Address #78. This uses the official telegram widget (iframe) to display individual message and I setup an aws lambda service to get the latest 10 message IDs from telegram groups: https://github.com/ailisp/cg-msg-counter/blob/main/index.js. There is no frontend-only solution to retrieve the message IDs.

Preview: https://near.social/#/bo.near/widget/gigs-board.pages.Feed?nearDevGovGigsContractAccountId=devgovgigs.near

Note that, due to #81 is not there, this PR uses hard coded telegram groups.

@ori-near ~I have trouble in layout these telegram messages in a beautiful way (they're iframes from https://t.me/`), may you take a look at the css here?~

There is no pure css way to make every iframe as height as the content. The JS way isn't work because near social VM prohibit direct access to DOM element. Therefore, I will modify the service to return messages as json and render with CSS to try looks close to telegram's UI