### PR TITLE
fix: rename notifications

### DIFF
--- a/src/DevGov/Notification/Item/Left.jsx
+++ b/src/DevGov/Notification/Item/Left.jsx
@@ -69,7 +69,7 @@ return props.type ? (
       ? "mentioned you in their"
       : "???"}{" "}
     <a className="fw-bold text-muted" href={href("Post", { id: props.post })}>
-      Developer Governance post
+        DevHub post
     </a>
   </>
 ) : (

--- a/src/DevGov/Notification/Item/Left.jsx
+++ b/src/DevGov/Notification/Item/Left.jsx
@@ -69,7 +69,7 @@ return props.type ? (
       ? "mentioned you in their"
       : "???"}{" "}
     <a className="fw-bold text-muted" href={href("Post", { id: props.post })}>
-        DevHub post
+      DevHub post
     </a>
   </>
 ) : (

--- a/src/DevGov/Notification/Item/Right.jsx
+++ b/src/DevGov/Notification/Item/Right.jsx
@@ -57,7 +57,7 @@ return props.post === undefined ? (
 ) : (
   <>
     <a className="btn btn-outline-dark" href={href("Post", { id: props.post })}>
-      View Developer Governance post
+      View DevHub post
     </a>
   </>
 );


### PR DESCRIPTION
fixed issue [#110](https://github.com/near/neardevhub-widgets/issues/110) [Notifications] Rename notifications and Reposts to DevHub.