### PR TITLE
fix: Set minimum height for app layout

### DIFF
--- a/src/gigs-board/components/layout/Page.jsx
+++ b/src/gigs-board/components/layout/Page.jsx
@@ -53,9 +53,9 @@ function href(widgetName, linkProps) {
 /* END_INCLUDE: "common.jsx" */
 
 return (
-  <>
+  <div className="h-100" style={{ minHeight: "86vh" }}>
     {widget("components.layout.app-header", {})}
     {props.header}
     {props.children}
-  </>
+  </div>
 );


### PR DESCRIPTION
Some elements may be cropped due to app layout height not being fixed.

Example:
<img width="930" alt="imagen" src="https://github.com/near/neardevhub-widgets/assets/8805308/0e1eda9a-b5a3-44d1-a862-7c70220e52ed">

With the given fix:
<img width="930" alt="imagen" src="https://github.com/near/neardevhub-widgets/assets/8805308/17b2f423-67ab-486a-a561-e6b88e918218">

Page shown on the screenshots:
https://near.org/devgovgigs.near/widget/gigs-board.pages.Post?id=696

Fix preview:
https://near.org/root.akaia.near/widget/gigs-board.pages.Post?id=696&nearDevGovGigsContractAccountId=devgovgigs.near
