### PR TITLE
Page improvements in community telegram page

### DIFF
--- a/src/gigs-board/pages/community/telegram.jsx
+++ b/src/gigs-board/pages/community/telegram.jsx
@@ -135,6 +135,16 @@ const Telegram = (
         minWidth: "100%",
       }}
     ></iframe>
+
+    <a href={"https://t.me/" + communityData.telegram_handle} target="_blank">
+      {widget("components.atom.button", {
+        classNames: {
+          root: "btn-primary",
+        },
+
+        label: "View More",
+      })}
+    </a>
   </div>
 );
 


### PR DESCRIPTION
Address the Page improvement part of #157 

Make links work isn't possible due to VM limitation. I made a pull request there: https://github.com/NearSocial/VM/pull/92. Other than that, this PR and changes in https://github.com/ailisp/cg-msg-counter.git did:


-    Sort by newest first (since it's not intuitive and we want the views to refresh for users)
-   Add "Recent posts" Title
-   Add button to view more posts to take you to Telegram channel-

Preview: https://near.social/#/bo.near/widget/gigs-board.pages.community.telegram?handle=protocol&nearDevGovGigsContractAccountId=devgovgigs.near

