### PR TITLE
fix: confirmation only for add/edit post

### DIFF
--- a/module/core/lib/draftstate.js
+++ b/module/core/lib/draftstate.js
@@ -1,6 +1,27 @@
 const DRAFT_STATE_STORAGE_KEY = "POST_DRAFT_STATE";
+let is_edit_or_add_post_transaction = false;
 if (props.transactionHashes) {
-  Storage.privateSet(DRAFT_STATE_STORAGE_KEY, undefined);
+  const transaction = fetch("https://rpc.mainnet.near.org", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "dontcare",
+      method: "tx",
+      params: [props.transactionHashes, context.accountId],
+    }),
+  });
+  const method_name =
+    transaction?.body?.result?.transaction?.actions[0].FunctionCall.method_name;
+
+  is_edit_or_add_post_transaction =
+    method_name == "add_post" || method_name == "edit_post";
+
+  if (is_edit_or_add_post_transaction) {
+    Storage.privateSet(DRAFT_STATE_STORAGE_KEY, undefined);
+  }
 }
 
 const onDraftStateChange = (draftState) =>

--- a/module/core/lib/draftstate.js
+++ b/module/core/lib/draftstate.js
@@ -1,5 +1,7 @@
 const DRAFT_STATE_STORAGE_KEY = "POST_DRAFT_STATE";
 let is_edit_or_add_post_transaction = false;
+let transaction_method_name;
+
 if (props.transactionHashes) {
   const transaction = fetch("https://rpc.mainnet.near.org", {
     method: "POST",
@@ -13,11 +15,12 @@ if (props.transactionHashes) {
       params: [props.transactionHashes, context.accountId],
     }),
   });
-  const method_name =
+  transaction_method_name =
     transaction?.body?.result?.transaction?.actions[0].FunctionCall.method_name;
 
   is_edit_or_add_post_transaction =
-    method_name == "add_post" || method_name == "edit_post";
+    transaction_method_name == "add_post" ||
+    transaction_method_name == "edit_post";
 
   if (is_edit_or_add_post_transaction) {
     Storage.privateSet(DRAFT_STATE_STORAGE_KEY, undefined);

--- a/src/gigs-board/entity/post/List.jsx
+++ b/src/gigs-board/entity/post/List.jsx
@@ -59,8 +59,29 @@ function href(widgetName, linkProps) {
 
 /* INCLUDE: "core/lib/draftstate" */
 const DRAFT_STATE_STORAGE_KEY = "POST_DRAFT_STATE";
+let is_edit_or_add_post_transaction = false;
 if (props.transactionHashes) {
-  Storage.privateSet(DRAFT_STATE_STORAGE_KEY, undefined);
+  const transaction = fetch("https://rpc.mainnet.near.org", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "dontcare",
+      method: "tx",
+      params: [props.transactionHashes, context.accountId],
+    }),
+  });
+  const method_name =
+    transaction?.body?.result?.transaction?.actions[0].FunctionCall.method_name;
+
+  is_edit_or_add_post_transaction =
+    method_name == "add_post" || method_name == "edit_post";
+
+  if (is_edit_or_add_post_transaction) {
+    Storage.privateSet(DRAFT_STATE_STORAGE_KEY, undefined);
+  }
 }
 
 const onDraftStateChange = (draftState) =>
@@ -438,7 +459,7 @@ const Head =
 return (
   <>
     {Head}
-    {props.transactionHashes ? (
+    {is_edit_or_add_post_transaction ? (
       <p class="text-secondary mt-4">
         Post submitted successfully. Back to{" "}
         <a

--- a/src/gigs-board/entity/post/List.jsx
+++ b/src/gigs-board/entity/post/List.jsx
@@ -60,6 +60,8 @@ function href(widgetName, linkProps) {
 /* INCLUDE: "core/lib/draftstate" */
 const DRAFT_STATE_STORAGE_KEY = "POST_DRAFT_STATE";
 let is_edit_or_add_post_transaction = false;
+let transaction_method_name;
+
 if (props.transactionHashes) {
   const transaction = fetch("https://rpc.mainnet.near.org", {
     method: "POST",
@@ -73,11 +75,12 @@ if (props.transactionHashes) {
       params: [props.transactionHashes, context.accountId],
     }),
   });
-  const method_name =
+  transaction_method_name =
     transaction?.body?.result?.transaction?.actions[0].FunctionCall.method_name;
 
   is_edit_or_add_post_transaction =
-    method_name == "add_post" || method_name == "edit_post";
+    transaction_method_name == "add_post" ||
+    transaction_method_name == "edit_post";
 
   if (is_edit_or_add_post_transaction) {
     Storage.privateSet(DRAFT_STATE_STORAGE_KEY, undefined);
@@ -461,7 +464,8 @@ return (
     {Head}
     {is_edit_or_add_post_transaction ? (
       <p class="text-secondary mt-4">
-        Post submitted successfully. Back to{" "}
+        Post {transaction_method_name == "edit_post" ? "edited" : "added"}{" "}
+        successfully. Back to{" "}
         <a
           style={{
             color: "#3252A6",

--- a/src/gigs-board/pages/Post.jsx
+++ b/src/gigs-board/pages/Post.jsx
@@ -55,6 +55,8 @@ function href(widgetName, linkProps) {
 /* INCLUDE: "core/lib/draftstate" */
 const DRAFT_STATE_STORAGE_KEY = "POST_DRAFT_STATE";
 let is_edit_or_add_post_transaction = false;
+let transaction_method_name;
+
 if (props.transactionHashes) {
   const transaction = fetch("https://rpc.mainnet.near.org", {
     method: "POST",
@@ -68,11 +70,12 @@ if (props.transactionHashes) {
       params: [props.transactionHashes, context.accountId],
     }),
   });
-  const method_name =
+  transaction_method_name =
     transaction?.body?.result?.transaction?.actions[0].FunctionCall.method_name;
 
   is_edit_or_add_post_transaction =
-    method_name == "add_post" || method_name == "edit_post";
+    transaction_method_name == "add_post" ||
+    transaction_method_name == "edit_post";
 
   if (is_edit_or_add_post_transaction) {
     Storage.privateSet(DRAFT_STATE_STORAGE_KEY, undefined);
@@ -87,10 +90,11 @@ try {
 } catch (e) {}
 /* END_INCLUDE: "core/lib/draftstate" */
 
-if (props.transactionHashes) {
+if (is_edit_or_add_post_transaction) {
   return (
     <p class="text-secondary">
-      Post submitted successfully. Back to{" "}
+      Post {transaction_method_name == "edit_post" ? "edited" : "added"}{" "}
+      successfully. Back to{" "}
       <a
         style={{
           color: "#3252A6",

--- a/src/gigs-board/pages/Post.jsx
+++ b/src/gigs-board/pages/Post.jsx
@@ -54,8 +54,29 @@ function href(widgetName, linkProps) {
 
 /* INCLUDE: "core/lib/draftstate" */
 const DRAFT_STATE_STORAGE_KEY = "POST_DRAFT_STATE";
+let is_edit_or_add_post_transaction = false;
 if (props.transactionHashes) {
-  Storage.privateSet(DRAFT_STATE_STORAGE_KEY, undefined);
+  const transaction = fetch("https://rpc.mainnet.near.org", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "dontcare",
+      method: "tx",
+      params: [props.transactionHashes, context.accountId],
+    }),
+  });
+  const method_name =
+    transaction?.body?.result?.transaction?.actions[0].FunctionCall.method_name;
+
+  is_edit_or_add_post_transaction =
+    method_name == "add_post" || method_name == "edit_post";
+
+  if (is_edit_or_add_post_transaction) {
+    Storage.privateSet(DRAFT_STATE_STORAGE_KEY, undefined);
+  }
 }
 
 const onDraftStateChange = (draftState) =>


### PR DESCRIPTION
This fix will check the method name of the returned transaction and only show the post confirmation screen if it is edit_post or add_post. This means that for a `like`, it will just return to the feed, and not show any confirmation screen. Also the confirmation screen now shows that post is added or edited.

Preview URL: https://near.org/devgovgigs.petersalomonsen.near/widget/gigs-board.pages.Feed?nearDevGovGigsContractAccountId=devgovgigs.petersalomonsen.near

fixes #209