### PR TITLE
Support buttons functioning as links

### DIFF
--- a/src/gigs-board/components/atom/button.jsx
+++ b/src/gigs-board/components/atom/button.jsx
@@ -1,150 +1,163 @@
-const ButtonRoot = styled.button`
-  padding: 0.5rem 0.75rem !important;
-  min-height: 42;
-  line-height: 1.5;
+const styles = `
+padding: 0.5rem 0.75rem !important;
+min-height: 42;
+line-height: 1.5;
+text-decoration: none !important;
 
-  &:not(.shadow-none) {
-    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important;
-    transition: box-shadow 0.6s;
-  }
+&:not(.shadow-none) {
+	box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important;
+	transition: box-shadow 0.6s;
+}
 
-  &:hover {
-    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important;
-  }
+&:hover {
+	box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important;
+}
 
-  &.btn-sm {
-    padding: 0.5rem 0.75rem !important;
-    min-height: 32;
-    line-height: 1;
-  }
+&.btn-sm {
+	padding: 0.5rem 0.75rem !important;
+	min-height: 32;
+	line-height: 1;
+}
 
-  &.btn-lg {
-    padding: 1rem 1.5rem !important;
-    min-height: 48;
-  }
+&.btn-lg {
+	padding: 1rem 1.5rem !important;
+	min-height: 48;
+}
 
-  &.btn-primary {
-    border: none;
-    --bs-btn-color: #ffffff;
-    --bs-btn-bg: #087990;
-    --bs-btn-border-color: #087990;
-    --bs-btn-hover-color: #ffffff;
-    --bs-btn-hover-bg: #055160;
-    --bs-btn-hover-border-color: #055160;
-    --bs-btn-focus-shadow-rgb: 49, 132, 253;
-    --bs-btn-active-color: #ffffff;
-    --bs-btn-active-bg: #055160;
-    --bs-btn-active-border-color: #055160;
-    --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-    --bs-btn-disabled-color: #ffffff;
-    --bs-btn-disabled-bg: #0551604a;
-  }
+&.btn-primary {
+	border: none;
+	--bs-btn-color: #ffffff;
+	--bs-btn-bg: #087990;
+	--bs-btn-border-color: #087990;
+	--bs-btn-hover-color: #ffffff;
+	--bs-btn-hover-bg: #055160;
+	--bs-btn-hover-border-color: #055160;
+	--bs-btn-focus-shadow-rgb: 49, 132, 253;
+	--bs-btn-active-color: #ffffff;
+	--bs-btn-active-bg: #055160;
+	--bs-btn-active-border-color: #055160;
+	--bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+	--bs-btn-disabled-color: #ffffff;
+	--bs-btn-disabled-bg: #0551604a;
+}
 
-  &.btn-outline-primary {
-    --bs-btn-disabled-color: #6c757d8f;
-  }
+&.btn-outline-primary {
+	--bs-btn-disabled-color: #6c757d8f;
+}
 
-  &.btn-secondary {
-    border: none;
-  }
+&.btn-secondary {
+	border: none;
+}
 
-  &.btn-outline-secondary {
-    --bs-btn-disabled-color: #6c757d8f;
-  }
+&.btn-outline-secondary {
+	--bs-btn-disabled-color: #6c757d8f;
+}
 
-  &.btn-success {
-    border: none;
-    --bs-btn-disabled-bg: #35482a4a;
-  }
+&.btn-success {
+	border: none;
+	--bs-btn-disabled-bg: #35482a4a;
+}
 
-  &.btn-outline-success {
-    --bs-btn-disabled-color: #6c757d8f;
-  }
+&.btn-outline-success {
+	--bs-btn-disabled-color: #6c757d8f;
+}
 
-  &.btn-danger {
-    border: none;
-  }
+&.btn-danger {
+	border: none;
+}
 
-  &.btn-outline-danger {
-    --bs-btn-disabled-color: #6c757d8f;
-  }
+&.btn-outline-danger {
+	--bs-btn-disabled-color: #6c757d8f;
+}
 
-  &.btn-warning {
-    border: none;
-  }
+&.btn-warning {
+	border: none;
+}
 
-  &.btn-outline-warning {
-    --bs-btn-disabled-color: #6c757d8f;
-  }
+&.btn-outline-warning {
+	--bs-btn-disabled-color: #6c757d8f;
+}
 
-  &.btn-info {
-    border: none;
-  }
+&.btn-info {
+	border: none;
+}
 
-  &.btn-outline-info {
-    --bs-btn-disabled-color: #6c757d8f;
-  }
+&.btn-outline-info {
+	--bs-btn-disabled-color: #6c757d8f;
+}
 
-  .adornmentHover {
-    display: none;
-  }
+.adornmentHover {
+	display: none;
+}
 
-  .label {
-    display: ${({ isCollapsible }) =>
-      isCollapsible ?? false ? "none" : "block"};
-  }
+.label {
+	display: ${({ isCollapsible }) => (isCollapsible ?? false ? "none" : "block")};
+}
 
-  &:hover {
-    & .adornment {
-      display: none;
-    }
+&:hover {
+	& .adornment {
+		display: none;
+	}
 
-    & .adornmentHover {
-      display: block;
-    }
+	& .adornmentHover {
+		display: block;
+	}
 
-    & .label {
-      display: block;
-    }
-  }
+	& .label {
+		display: block;
+	}
+}
 `;
 
-const Button = ({ adornment, classNames, label, ...restProps }) => (
-  <ButtonRoot
-    className={[
-      "btn d-inline-flex align-items-center gap-2 rounded-pill",
-      restProps.isCollapsible ? "collapsible" : "",
-      classNames.root ?? "btn-primary",
-    ].join(" ")}
-    style={{ width: "fit-content" }}
-    {...restProps}
-  >
-    {(adornment ?? null) !== null ? adornment : null}
+const rootElementByType = (type) =>
+  type === "link"
+    ? styled.a`
+        ${styles}
+      `
+    : styled.button`
+        ${styles}
+      `;
 
-    {(adornment ?? null) === null && classNames.adornment ? (
-      <i
-        className={[
-          classNames.adornment,
-          (classNames.adornmentHover ?? null) === null ? "" : "adornment",
-        ].join(" ")}
-        style={{ lineHeight: !restProps.isCollapsible ? 1 : 1.5 }}
-      />
-    ) : null}
+const Button = ({ adornment, classNames, label, type, ...restProps }) => {
+  const ButtonRoot = rootElementByType(type);
 
-    {(adornment ?? null) === null && classNames.adornmentHover ? (
-      <i
-        className={[classNames.adornmentHover, "adornmentHover"].join(" ")}
-        style={{ lineHeight: !restProps.isCollapsible ? 1 : 1.5 }}
-      />
-    ) : null}
-
-    <span
-      className={[classNames.label, "label"].join(" ")}
-      style={{ lineHeight: "inherit" }}
+  return (
+    <ButtonRoot
+      className={[
+        "btn d-inline-flex align-items-center gap-2 rounded-pill",
+        restProps.isCollapsible ? "collapsible" : "",
+        classNames.root ?? "btn-primary",
+      ].join(" ")}
+      style={{ width: "fit-content" }}
+      {...restProps}
     >
-      {label}
-    </span>
-  </ButtonRoot>
-);
+      {(adornment ?? null) !== null ? adornment : null}
+
+      {(adornment ?? null) === null && classNames.adornment ? (
+        <i
+          className={[
+            classNames.adornment,
+            (classNames.adornmentHover ?? null) === null ? "" : "adornment",
+          ].join(" ")}
+          style={{ lineHeight: !restProps.isCollapsible ? 1 : 1.5 }}
+        />
+      ) : null}
+
+      {(adornment ?? null) === null && classNames.adornmentHover ? (
+        <i
+          className={[classNames.adornmentHover, "adornmentHover"].join(" ")}
+          style={{ lineHeight: !restProps.isCollapsible ? 1 : 1.5 }}
+        />
+      ) : null}
+
+      <span
+        className={[classNames.label, "label"].join(" ")}
+        style={{ lineHeight: "inherit" }}
+      >
+        {label}
+      </span>
+    </ButtonRoot>
+  );
+};
 
 return Button(props);

--- a/src/gigs-board/feature/github-integration/kanban-board-editor.jsx
+++ b/src/gigs-board/feature/github-integration/kanban-board-editor.jsx
@@ -101,37 +101,37 @@ const useForm = ({ initialValues, stateKey: formStateKey, uninitialized }) => {
       hasUnsubmittedChanges: false,
     }));
 
-  const formUpdate = ({ path, via: customFieldUpdate, ...params }) => (
-    fieldInput
-  ) => {
-    const updatedValues = Struct.deepFieldUpdate(
-      formState?.values ?? {},
+  const formUpdate =
+    ({ path, via: customFieldUpdate, ...params }) =>
+    (fieldInput) => {
+      const updatedValues = Struct.deepFieldUpdate(
+        formState?.values ?? {},
 
-      {
-        input: fieldInput?.target?.value ?? fieldInput,
-        params,
-        path,
+        {
+          input: fieldInput?.target?.value ?? fieldInput,
+          params,
+          path,
 
-        via:
-          typeof customFieldUpdate === "function"
-            ? customFieldUpdate
-            : defaultFieldUpdate,
-      }
-    );
+          via:
+            typeof customFieldUpdate === "function"
+              ? customFieldUpdate
+              : defaultFieldUpdate,
+        }
+      );
 
-    State.update((lastKnownComponentState) => ({
-      ...lastKnownComponentState,
+      State.update((lastKnownComponentState) => ({
+        ...lastKnownComponentState,
 
-      [formStateKey]: {
-        hasUnsubmittedChanges: !Struct.isEqual(
-          updatedValues,
-          initialFormState.values
-        ),
+        [formStateKey]: {
+          hasUnsubmittedChanges: !Struct.isEqual(
+            updatedValues,
+            initialFormState.values
+          ),
 
-        values: updatedValues,
-      },
-    }));
-  };
+          values: updatedValues,
+        },
+      }));
+    };
 
   if (
     !uninitialized &&
@@ -419,10 +419,12 @@ const GithubKanbanBoardEditor = ({ communityHandle, pageURL }) => {
         }
       : lastKnownValue;
 
-  const columnsDeleteById = (id) => ({ lastKnownValue }) =>
-    Object.fromEntries(
-      Object.entries(lastKnownValue).filter(([columnId]) => columnId !== id)
-    );
+  const columnsDeleteById =
+    (id) =>
+    ({ lastKnownValue }) =>
+      Object.fromEntries(
+        Object.entries(lastKnownValue).filter(([columnId]) => columnId !== id)
+      );
 
   const onSubmit = () =>
     DevHub.edit_community_github({


### PR DESCRIPTION
Allows rendering buttons using \<a /\> as the root element.

```
{widget("components.atom.button", {
  href: href("community.configure", { handle }),
  label: "Configure community",
  type: "link",
})}
```

## Preview

Mainnet: https://near.org/carina.akaia.near/widget/gigs-board.pages.community.activity?handle=protocol&nearDevGovGigsContractAccountId=devgovgigs.near