### PR TITLE
Feature/231 mobile friendly

### DIFF
--- a/src/gigs-board/entity/community/card.jsx
+++ b/src/gigs-board/entity/community/card.jsx
@@ -52,21 +52,18 @@ function href(widgetName, linkProps) {
 }
 /* END_INCLUDE: "common.jsx" */
 /* INCLUDE: "core/lib/gui/attractable" */
-const AttractableDiv = styled.div`
-  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important;
-  transition: box-shadow 0.6s;
-
-  &:hover {
-    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important;
-  }
-`;
 
 const AttractableLink = styled.a`
   box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important;
   transition: box-shadow 0.6s;
+  width: 23%;
 
   &:hover {
     box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important;
+  }
+
+  @media (max-width: 768px) {
+    width: 45%;
   }
 `;
 
@@ -148,7 +145,7 @@ const CommunityCard = ({
     <AttractableLink
       className="card d-flex flex-column flex-shrink-0 text-decoration-none text-reset"
       href={link}
-      style={{ width: "23%", maxWidth: 304 }}
+      style={{ maxWidth: 304 }}
     >
       <div
         className="card-img-top w-100"

--- a/src/gigs-board/feature/post-search/panel.jsx
+++ b/src/gigs-board/feature/post-search/panel.jsx
@@ -673,10 +673,31 @@ const showMoreSearchResults = () => {
   State.update({ shownSearchResults: newShownSearchResults });
 };
 
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1.5rem !important;
+
+  @media only screen and (max-width: 768px) {
+    flex-direction: column !important;
+  }
+`;
+
+const InputContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  position: relative;
+  width: 25%;
+
+  @media only screen and (max-width: 768px) {
+    width: 100%;
+  }
+`;
+
 return (
   <>
-    <div className="d-flex flex-row gap-4">
-      <div className="d-flex flex-row position-relative w-25">
+    <Container className="d-flex flex-row gap-4">
+      <InputContainer>
         <div className="position-absolute d-flex ps-3 flex-column h-100 justify-center">
           {state.loading ? (
             <span
@@ -695,7 +716,7 @@ return (
           onChange={(e) => updateInput(e.target.value)}
           placeholder={props.placeholder ?? `Search Posts`}
         />
-      </div>
+      </InputContainer>
       <div class="dropdown">
         <button
           class="btn btn-light dropdown-toggle"
@@ -750,7 +771,7 @@ return (
       <div className="d-flex flex-row-reverse flex-grow-1">
         {props.children}
       </div>
-    </div>
+    </Container>
     {state.processedQuery &&
       state.processedQuery.length > 0 &&
       state.term.toLowerCase().trim() !== state.processedQuery.join(" ") && (

--- a/src/gigs-board/pages/Feed.jsx
+++ b/src/gigs-board/pages/Feed.jsx
@@ -177,6 +177,16 @@ const Gradient = styled.div`
   }
 `;
 
+const CardWrapper = styled.div`
+  display: flex;
+  gap: 1.5em !important;
+  justify-content: space-between;
+
+  @media only screen and (max-width: 768px) {
+    flex-wrap: wrap;
+  }
+`;
+
 const banner = (
   <div className="d-flex flex-column">
     <Gradient className="d-flex flex-column justify-content-center">
@@ -197,7 +207,7 @@ const banner = (
       <div className="d-flex justify-content-between">
         <h5 className="h5 m-0">Featured Communities</h5>
       </div>
-      <div className="d-flex gap-4 justify-content-between">
+      <CardWrapper>
         {(DevHub.get_featured_communities() ?? []).map((community) =>
           widget(
             "entity.community.card",
@@ -205,7 +215,7 @@ const banner = (
             community.handle
           )
         )}
-      </div>
+      </CardWrapper>
     </div>
 
     <div className="h5 pb-4">Activity</div>


### PR DESCRIPTION
_Resolves #231_

The PR is a draft, I still need to populate the community cards in the preview;

[Preview](https://near.org/thomasguntenaar.near/widget/gigs-board.pages.Feed)

These changes are made to the landing page of DevHub:

- [x] The search filters dropdown and post button are now vertically stacked because they didn't fit horizontally.

- [x] The community cards on the home page are now stacked 2x2 instead of horizontally which made them unreadable.
