### PR TITLE
fix: main branch deploy action

### DIFF
--- a/replacements.mainnet.json
+++ b/replacements.mainnet.json
@@ -1,0 +1,7 @@
+{
+  "REPL_DEVHUB": "devgovgigs.near",
+  "REPL_DEVHUB_CONTRACT": "devgovgigs.near",
+  "REPL_NEAR": "near",
+  "REPL_MOB": "mob.near",
+  "REPL_EFIZ": "efiz.near"
+}

--- a/replacements.testnet.json
+++ b/replacements.testnet.json
@@ -1,5 +1,5 @@
 {
-  "REPL_DEVHUB": "devhub.testnet",
+  "REPL_DEVHUB": "devhubtest.testnet",
   "REPL_DEVHUB_CONTRACT": "thomaspreview.testnet",
   "REPL_NEAR": "discom.testnet",
   "REPL_MOB": "eugenethedream",


### PR DESCRIPTION
The main branch testnet deploy was configured with devhub.testnet.

I'm sure somebody has it, but I will not go chasing for it. Changed to devhubtest.testnet.