### PR TITLE
Fix sort on new app

### DIFF
--- a/src/devhub/feature/post-search/panel.jsx
+++ b/src/devhub/feature/post-search/panel.jsx
@@ -72,7 +72,10 @@ return (
                   <a
                     style={{ borderRadius: "5px" }}
                     class="dropdown-item link-underline link-underline-opacity-0"
-                    href={href("Feed")}
+                    href={href({
+                      widgetSrc: "${REPL_DEVHUB}/widget/app",
+                      params: { page: "feed" },
+                    })}
                   >
                     Latest
                   </a>
@@ -81,7 +84,11 @@ return (
                   <a
                     style={{ borderRadius: "5px" }}
                     class="dropdown-item link-underline link-underline-opacity-0"
-                    href={href("Feed", { recency: "all" })}
+                    href={href({
+                      widgetSrc: "${REPL_DEVHUB}/widget/app",
+                      params: { page: "feed" },
+                      recency: "all",
+                    })}
                   >
                     All replies
                   </a>


### PR DESCRIPTION
Sort on new app https://near.social/devgovgigs.near/widget/app?page=feed is broken. This PR fix it.

@elliotBraem  How to preview the new app on mainnet, with widgets from bo.near but devgovgigs.near contract?

Previously I have: https://near.social/bo.near/widget/gigs-board.pages.Feed?nearDevGovGigsContractAccountId=devgovgigs.near

but this doesn't work: https://near.social/bo.near/widget/app?nearDevGovGigsContractAccountId=devgovgigs.near&page=feed