### PR TITLE
Fix: Typos and numbering in participate section

### DIFF
--- a/src/devhub/components/island/connect.jsx
+++ b/src/devhub/components/island/connect.jsx
@@ -90,7 +90,7 @@ const Card = ({ title, description, href }) => {
 
 const Cards = [
   {
-    title: "Devhub Hacks",
+    title: "DevHub Hacks",
     description: "Host and support developer focused events around the globe.",
     href: "/${REPL_DEVHUB}/widget/app?page=community&handle=hacks",
   },

--- a/src/devhub/components/island/participate.jsx
+++ b/src/devhub/components/island/participate.jsx
@@ -36,19 +36,19 @@ const Links = [
   {
     links: [
       {
-        title: "Ideate on Devhub",
+        title: "Ideate on DevHub",
         href: "/devhub.near/widget/app?page=blog&id=2029",
         count: 1,
       },
       {
         title: "Post a Proposal",
         href: "/devhub.near/widget/app?page=blog&id=2035",
-        count: 4,
+        count: 2,
       },
       {
         title: "Host an Event",
         href: "/devhub.near/widget/app?page=community&handle=hacks&tab=Wiki%202",
-        count: 7,
+        count: 3,
       },
     ],
   },
@@ -57,26 +57,26 @@ const Links = [
       {
         title: "Improve NEAR Docs",
         href: "https://github.com/near/docs",
-        count: 2,
+        count: 4,
       },
       {
         title: "Join the Fellowship",
         href: "/devhub.near/widget/app?page=community&handle=fellowship&tab=Wiki%201",
         count: 5,
       },
+      {
+        title: "Join NEAR Campus",
+        href: "/devhub.near/widget/app?page=community&handle=near-campus",
+        count: 6,
+      },
     ],
   },
   {
     links: [
       {
-        title: "Join NEAR Campus",
-        href: "/devhub.near/widget/app?page=community&handle=near-campus",
-        count: 3,
-      },
-      {
         title: "Dive into Hackbox",
         href: "/hackbox.near/widget/home",
-        count: 6,
+        count: 7,
       },
     ],
   },

--- a/src/devhub/page/contribute.jsx
+++ b/src/devhub/page/contribute.jsx
@@ -48,7 +48,7 @@ const Container = styled.div`
 
 const actions = [
   {
-    title: "Ideate on Devhub",
+    title: "Ideate on DevHub",
     description:
       "The first step in any NEAR ecosystem project is ideation. It is crucial to have a way to find people to share and explore ideas with, partly because it can save a lot of time based on prior discussions. But also because it can you gauge support from a diversity of stakeholders.",
     ctaAction: "Learn More →",


### PR DESCRIPTION
- Fixed typos. Changed Devhub to DevHub according to brand guidelines.
- Fixed numbering of actions on participate section.