### PR TITLE
Expanded posts replies shows visual indicator to close replies

### DIFF
--- a/src/devhub/entity/post/Post.jsx
+++ b/src/devhub/entity/post/Post.jsx
@@ -12,9 +12,17 @@ if (!href) {
 
 const ButtonWithHover = styled.button`
   background-color: #fff;
+  transition: all 300ms;
+  border-radius: 0.5rem;
+
   &:hover {
     background-color: #e9ecef;
     color: #000;
+  }
+
+  &:disabled {
+    background-color: #fff;
+    color: #b7b7b7;
   }
 `;
 
@@ -401,18 +409,27 @@ const buttonsFooter = props.isPreview ? null : (
             )}
           </ul>
         </div>
-        <ButtonWithHover
-          type="button"
-          class="btn"
-          style={{ border: "0px" }}
-          data-bs-toggle="collapse"
-          href={`#collapseChildPosts${postId}`}
-          aria-expanded={defaultExpanded}
-          aria-controls={`collapseChildPosts${postId}`}
-        >
-          <i class="bi bi-chevron-down"> </i>{" "}
-          {`Expand Replies (${childPostIds.length})`}
-        </ButtonWithHover>
+        {childPostIds.length > 0 && (
+          <ButtonWithHover
+            type="button"
+            class="btn"
+            style={{ border: "0px" }}
+            data-bs-toggle="collapse"
+            href={`#collapseChildPosts${postId}`}
+            aria-expanded={defaultExpanded}
+            aria-controls={`collapseChildPosts${postId}`}
+            onClick={() =>
+              State.update({ expandReplies: !state.expandReplies })
+            }
+          >
+            <i
+              class={`bi bi-chevron-${state.expandReplies ? "up" : "down"}`}
+            ></i>{" "}
+            {`${state.expandReplies ? "Collapse" : "Expand"} Replies (${
+              childPostIds.length
+            })`}
+          </ButtonWithHover>
+        )}
 
         {isUnderPost || !parentId ? (
           <div key="link-to-parent"></div>
@@ -701,18 +718,20 @@ const postsList =
         id={`collapseChildPosts${postId}`}
       >
         {childPostIds.map((childId) => (
-          <Widget
-            src="${REPL_DEVHUB}/widget/devhub.entity.post.Post"
-            props={{
-              id: childId,
-              isUnderPost: true,
-              onDraftStateChange,
-              draftState,
-              expandParent: () =>
-                State.update({ childrenOfChildPostsHasDraft: true }),
-              referral: `subpost${childId}of${postId}`,
-            }}
-          />
+          <div key={childId} style={{ marginBottom: "0.5rem" }}>
+            <Widget
+              src="${REPL_DEVHUB}/widget/devhub.entity.post.Post"
+              props={{
+                id: childId,
+                isUnderPost: true,
+                onDraftStateChange,
+                draftState,
+                expandParent: () =>
+                  State.update({ childrenOfChildPostsHasDraft: true }),
+                referral: `subpost${childId}of${postId}`,
+              }}
+            />
+          </div>
         ))}
       </div>
     </div>
@@ -729,6 +748,7 @@ const needClamp = isInList && contentArray.length > 5;
 
 initState({
   clamp: needClamp,
+  expandReplies: defaultExpanded,
 });
 
 const clampedContent = needClamp


### PR DESCRIPTION
Resolved https://github.com/near/neardevhub-widgets/issues/311

Proposed changes include:
- Show Collapse Replies + change arrow direction to let user know replies are open
<img width="310" alt="image" src="https://github.com/near/neardevhub-widgets/assets/46527178/431ff27b-d181-42ec-af8e-a2e5205293c6">

- Hide expand replies option when there are no replies
<img width="221" alt="image" src="https://github.com/near/neardevhub-widgets/assets/46527178/cf793d45-a63e-4e76-8f22-61e9b1b61eed">

- Added bottom margin to replies to separate replies
<img width="813" alt="image" src="https://github.com/near/neardevhub-widgets/assets/46527178/25898471-e749-4fb0-b979-2e222dbcd855">
