### PR TITLE
use v36 indexer which include old posts id < 60

### DIFF
--- a/src/devhub/entity/addon/blog/Feed.jsx
+++ b/src/devhub/entity/addon/blog/Feed.jsx
@@ -25,7 +25,7 @@ const fetchGraphQL = (operationsDoc, operationName, variables) => {
 };
 
 const queryName =
-  props.queryName ?? `bo_near_devhub_v35_posts_with_latest_snapshot`;
+  props.queryName ?? `bo_near_devhub_v36_posts_with_latest_snapshot`;
 
 const query = `query DevhubPostsQuery($limit: Int = 100, $offset: Int = 0, $where: ${queryName}_bool_exp = {}) {
     ${queryName}(

--- a/src/devhub/entity/addon/blog/editor/provider.jsx
+++ b/src/devhub/entity/addon/blog/editor/provider.jsx
@@ -132,7 +132,7 @@ const handleOnCancel = (v) => {
 
 return (
   <Layout
-    data={posts.body.data.bo_near_devhub_v35_posts_with_latest_snapshot || []}
+    data={posts.body.data.bo_near_devhub_v36_posts_with_latest_snapshot || []}
     getData={handleGetData}
     onChange={handleOnChange}
     onSubmit={handleOnSubmit}

--- a/src/devhub/entity/post/List.jsx
+++ b/src/devhub/entity/post/List.jsx
@@ -16,7 +16,7 @@ if (!href) {
 const QUERYAPI_ENDPOINT = `https://near-queryapi.api.pagoda.co/v1/graphql/`;
 
 const queryName =
-  props.queryName ?? `bo_near_devhub_v35_posts_with_latest_snapshot`;
+  props.queryName ?? `bo_near_devhub_v36_posts_with_latest_snapshot`;
 
 const query = `query DevhubPostsQuery($limit: Int = 100, $offset: Int = 0, $where: ${queryName}_bool_exp = {}) {
     ${queryName}(


### PR DESCRIPTION
devhub_v36 indexer includes old post ids < 60 by running a script after deployment. It also should include new posts. Since https://github.com/near/queryapi/issues/407, the older indexers stop pick up new blocks but the newest indexer works just fine