### PR TITLE
fix ordering

### DIFF
--- a/src/devhub/entity/addon/blog/Feed.jsx
+++ b/src/devhub/entity/addon/blog/Feed.jsx
@@ -31,7 +31,7 @@ const query = `query DevhubPostsQuery($limit: Int = 100, $offset: Int = 0, $wher
     ${queryName}(
       limit: $limit
       offset: $offset
-      order_by: {block_height: desc}
+      order_by: {ts: desc}
       where: $where
     ) {
       post_id

--- a/src/devhub/entity/post/List.jsx
+++ b/src/devhub/entity/post/List.jsx
@@ -22,7 +22,7 @@ const query = `query DevhubPostsQuery($limit: Int = 100, $offset: Int = 0, $wher
     ${queryName}(
       limit: $limit
       offset: $offset
-      order_by: {block_height: desc}
+      order_by: {ts: desc}
       where: $where
     ) {
       post_id


### PR DESCRIPTION
Old posts (id < 60) from state dump don't have a block height but all posts have timestamp, sort by timestamp fix the ordering