### PR TITLE
Hide posts with "devhub-test" tag from feed

### DIFF
--- a/playwright-tests/tests/feed.spec.js
+++ b/playwright-tests/tests/feed.spec.js
@@ -52,8 +52,8 @@ test("should hide posts with devhub-test tag", async ({ page }) => {
   // look for tag input
   const tagInputSelector = 'input[placeholder="Search by tag"]';
   await page.waitForSelector(tagInputSelector, {
-    state: 'visible'
-  })
+    state: "visible",
+  });
   await page.click(tagInputSelector);
 
   // select devhub-test
@@ -61,11 +61,12 @@ test("should hide posts with devhub-test tag", async ({ page }) => {
   await page.click(testingTagSelector);
 
   // check if no posts are found
-  const noPostFoundSelector = 'p.text-secondary:has-text("No posts matches search")';
+  const noPostFoundSelector =
+    'p.text-secondary:has-text("No posts matches search")';
   await page.waitForSelector(noPostFoundSelector, {
-    state: 'visible'
-  })
-})
+    state: "visible",
+  });
+});
 
 test.describe("Wallet is connected", () => {
   // sign in to wallet

--- a/playwright-tests/tests/feed.spec.js
+++ b/playwright-tests/tests/feed.spec.js
@@ -45,6 +45,28 @@ test("should show post history for posts in the feed", async ({ page }) => {
   await page.waitForSelector(desiredChildSelector, { state: "visible" });
 });
 
+test("should hide posts with devhub-test tag", async ({ page }) => {
+  // go to feeds page
+  await page.goto("/devhub.near/widget/app?page=feed");
+
+  // look for tag input
+  const tagInputSelector = 'input[placeholder="Search by tag"]';
+  await page.waitForSelector(tagInputSelector, {
+    state: 'visible'
+  })
+  await page.click(tagInputSelector);
+
+  // select devhub-test
+  const testingTagSelector = 'a.dropdown-item[aria-label="devhub-test"]';
+  await page.click(testingTagSelector);
+
+  // check if no posts are found
+  const noPostFoundSelector = 'p.text-secondary:has-text("No posts matches search")';
+  await page.waitForSelector(noPostFoundSelector, {
+    state: 'visible'
+  })
+})
+
 test.describe("Wallet is connected", () => {
   // sign in to wallet
   test.use({

--- a/src/devhub/entity/post/List.jsx
+++ b/src/devhub/entity/post/List.jsx
@@ -94,13 +94,22 @@ function getPostIds() {
     where = { parent_id: { _is_null: true }, ...where };
   }
 
-  // Don't show blog
+  // Don't show blog and devhub-test posts
   where = {
-    _not: {
-      labels: { _contains: "blog" },
-      parent_id: { _is_null: true },
-      post_type: { _eq: "Comment" },
-    },
+    _and: [
+      {
+        _not: {
+          labels: { _contains: "blog" },
+          parent_id: { _is_null: true },
+          post_type: { _eq: "Comment" },
+        },
+      },
+      {
+        _not: {
+          labels: { _contains: "devhub-test" },
+        },
+      },
+    ],
     ...where,
   };
 


### PR DESCRIPTION
Resolved https://github.com/near/neardevhub-widgets/issues/479

The posts with tag "devhub-test" are hidden from the feed by default, but they can be viewed when searching for "devhub-test" tag