### PR TITLE
Community Activity takes full space on desktop when no posts

### DIFF
--- a/src/devhub/entity/community/Activity.jsx
+++ b/src/devhub/entity/community/Activity.jsx
@@ -35,7 +35,7 @@ const SidebarContainer = styled.div`
 `;
 
 return (
-  <div style={{ maxWidth: "100%" }}>
+  <div style={{ maxWidth: "100%", width: "100%" }}>
     <div class="col">
       <div class="d-flex w-100">
         <MainContent>


### PR DESCRIPTION
Resolved https://github.com/near/neardevhub-widgets/issues/529