### PR TITLE
Add sponsorship information in post editor

### DIFF
--- a/src/devhub/entity/post/Post.jsx
+++ b/src/devhub/entity/post/Post.jsx
@@ -561,9 +561,9 @@ const toggleEditor = () => {
   State.update({ showEditor: !state.showEditor });
 };
 
-let amount;
-let token;
-let supervisor;
+let amount = null;
+let token = null;
+let supervisor = null;
 
 if (state.postType === "Solution") {
   const amountMatch = post.snapshot.description.match(

--- a/src/devhub/entity/post/Post.jsx
+++ b/src/devhub/entity/post/Post.jsx
@@ -571,7 +571,8 @@ const sponsorMatch = post.snapshot.description.match(
   /Requested sponsor: @([^\s]+)/
 );
 const sponsorTag = sponsorMatch ? sponsorMatch[1] : null;
-const seekingFunding = amount !== 0 || currency !== "" || sponsorTag !== "";
+const seekingFunding =
+  amount !== null || currency !== null || sponsorTag !== null;
 
 function Editor() {
   return (

--- a/src/devhub/entity/post/Post.jsx
+++ b/src/devhub/entity/post/Post.jsx
@@ -561,6 +561,18 @@ const toggleEditor = () => {
   State.update({ showEditor: !state.showEditor });
 };
 
+const amountMatch = post.snapshot.description.match(
+  /Requested amount: (\d+(\.\d+)?) (\w+)/
+);
+const amount = amountMatch ? parseFloat(amountMatch[1]) : null;
+const currency = amountMatch ? amountMatch[3] : null;
+
+const sponsorMatch = post.snapshot.description.match(
+  /Requested sponsor: @([^\s]+)/
+);
+const sponsorTag = sponsorMatch ? sponsorMatch[1] : null;
+const seekingFunding = amount !== 0 || currency !== "" || sponsorTag !== "";
+
 function Editor() {
   return (
     <div class="row" id={`accordion${postId}`} key="editors-footer">
@@ -595,9 +607,13 @@ function Editor() {
                 labels: post.snapshot.labels,
                 name: post.snapshot.name,
                 description: post.snapshot.description,
-                amount: post.snapshot.amount,
-                token: tokenResolver(post.snapshot.sponsorship_token),
-                supervisor: post.snapshot.supervisor,
+                amount: post.snapshot.amount || amount,
+                token: tokenResolver(
+                  post.snapshot.sponsorship_token || currency
+                ),
+                supervisor:
+                  post.snapshot.post.snapshot.supervisor || sponsorTag,
+                seekingFunding: seekingFunding,
                 githubLink: post.snapshot.github_link,
                 onDraftStateChange,
                 draftState:

--- a/src/devhub/entity/post/Post.jsx
+++ b/src/devhub/entity/post/Post.jsx
@@ -561,18 +561,24 @@ const toggleEditor = () => {
   State.update({ showEditor: !state.showEditor });
 };
 
-const amountMatch = post.snapshot.description.match(
-  /Requested amount: (\d+(\.\d+)?) (\w+)/
-);
-const amount = amountMatch ? parseFloat(amountMatch[1]) : null;
-const currency = amountMatch ? amountMatch[3] : null;
+let amount;
+let token;
+let supervisor;
 
-const sponsorMatch = post.snapshot.description.match(
-  /Requested sponsor: @([^\s]+)/
-);
-const sponsorTag = sponsorMatch ? sponsorMatch[1] : null;
-const seekingFunding =
-  amount !== null || currency !== null || sponsorTag !== null;
+if (state.postType === "Solution") {
+  const amountMatch = post.snapshot.description.match(
+    /Requested amount: (\d+(\.\d+)?) (\w+)/
+  );
+  amount = amountMatch ? parseFloat(amountMatch[1]) : null;
+  token = amountMatch ? amountMatch[3] : null;
+
+  const sponsorMatch = post.snapshot.description.match(
+    /Requested sponsor: @([^\s]+)/
+  );
+  supervisor = sponsorMatch ? sponsorMatch[1] : null;
+}
+
+const seekingFunding = amount !== null || token !== null || supervisor !== null;
 
 function Editor() {
   return (
@@ -609,11 +615,9 @@ function Editor() {
                 name: post.snapshot.name,
                 description: post.snapshot.description,
                 amount: post.snapshot.amount || amount,
-                token: tokenResolver(
-                  post.snapshot.sponsorship_token || currency
-                ),
+                token: tokenResolver(post.snapshot.sponsorship_token || token),
                 supervisor:
-                  post.snapshot.post.snapshot.supervisor || sponsorTag,
+                  post.snapshot.post.snapshot.supervisor || supervisor,
                 seekingFunding: seekingFunding,
                 githubLink: post.snapshot.github_link,
                 onDraftStateChange,

--- a/src/devhub/entity/post/PostEditor.jsx
+++ b/src/devhub/entity/post/PostEditor.jsx
@@ -43,10 +43,6 @@ const labels = labelStrings.map((s) => {
 });
 
 const cleanDescription = (description) => {
-  if (props.postType !== "Solution") {
-    return description;
-  }
-
   return description.replace(
     /###### Requested amount: .+?\n###### Requested sponsor: @[^\s]+\n/g,
     ""
@@ -63,7 +59,10 @@ initState({
   labelStrings,
   postType,
   name: props.name ?? "",
-  description: cleanDescription(props.description) ?? "",
+  description:
+    (props.postType === "Solution"
+      ? cleanDescription(props.description)
+      : props.description) ?? "",
   amount: props.amount ?? "0",
   token: props.token ?? "USDT",
   supervisor: props.supervisor ?? "neardevdao.near",

--- a/src/devhub/entity/post/PostEditor.jsx
+++ b/src/devhub/entity/post/PostEditor.jsx
@@ -43,6 +43,10 @@ const labels = labelStrings.map((s) => {
 });
 
 const cleanDescription = (description) => {
+  if (props.postType !== "Solution") {
+    return description;
+  }
+
   return description.replace(
     /###### Requested amount: .+?\n###### Requested sponsor: @[^\s]+\n/g,
     ""

--- a/src/devhub/entity/post/PostEditor.jsx
+++ b/src/devhub/entity/post/PostEditor.jsx
@@ -42,8 +42,15 @@ const labels = labelStrings.map((s) => {
   return { name: s };
 });
 
+const cleanDescription = (description) => {
+  return description.replace(
+    /###### Requested amount: .+?\n###### Requested sponsor: @[^\s]+\n/g,
+    ""
+  );
+};
+
 initState({
-  seekingFunding: false,
+  seekingFunding: props.seekingFunding ?? false,
   author_id: context.accountId,
   // Should be a list of objects with field "name".
   labels,
@@ -52,7 +59,7 @@ initState({
   labelStrings,
   postType,
   name: props.name ?? "",
-  description: props.description ?? "",
+  description: cleanDescription(props.description) ?? "",
   amount: props.amount ?? "0",
   token: props.token ?? "USDT",
   supervisor: props.supervisor ?? "neardevdao.near",


### PR DESCRIPTION
Resolved https://github.com/near/neardevhub-widgets/issues/469

The cause of this issue was due to the props not being saved with post. The props being passed to the editor didn't exist. So I wrote some regex to extract those props from the description and used them.
For future posts, I recommend saving these props when creating the post.

https://github.com/near/neardevhub-widgets/assets/46527178/2f671f26-4771-42eb-bed5-5066a5b54425
