### PR TITLE
removes deposit and reduces gas (#551)

### DIFF
--- a/src/devhub/entity/addon/blog/editor/provider.jsx
+++ b/src/devhub/entity/addon/blog/editor/provider.jsx
@@ -105,8 +105,7 @@ const handleOnSubmit = (v, isEdit) => {
           comment_version: "V2",
         },
       },
-      deposit: Big(10).pow(21).mul(2),
-      gas: Big(10).pow(12).mul(100),
+      gas: Big(10).pow(14),
     });
   } else {
     Near.call({
@@ -120,8 +119,7 @@ const handleOnSubmit = (v, isEdit) => {
           comment_version: "V2",
         },
       },
-      deposit: Big(10).pow(21).mul(2),
-      gas: Big(10).pow(12).mul(100),
+      gas: Big(10).pow(14),
     });
   }
 };

--- a/src/devhub/entity/post/Post.jsx
+++ b/src/devhub/entity/post/Post.jsx
@@ -283,8 +283,7 @@ const onLike = () => {
       args: {
         post_id: postId,
       },
-      deposit: Big(10).pow(21).mul(2),
-      gas: Big(10).pow(12).mul(100),
+      gas: Big(10).pow(14),
     },
   ];
 
@@ -296,8 +295,7 @@ const onLike = () => {
         predecessor_id: "${REPL_DEVHUB_CONTRACT}",
         keys: [context.accountId + "/index/notify"],
       },
-      deposit: Big(10).pow(23),
-      gas: Big(10).pow(12).mul(30),
+      gas: Big(10).pow(14),
     });
   }
 

--- a/src/devhub/entity/post/PostEditor.jsx
+++ b/src/devhub/entity/post/PostEditor.jsx
@@ -172,8 +172,7 @@ const onSubmit = () => {
         labels,
         body,
       },
-      deposit: Big(10).pow(21).mul(2),
-      gas: Big(10).pow(12).mul(100),
+      gas: Big(10).pow(14),
     });
   } else if (mode == "Edit") {
     props.onDraftStateChange(
@@ -187,8 +186,7 @@ const onSubmit = () => {
         labels,
         body,
       },
-      deposit: Big(10).pow(21).mul(2),
-      gas: Big(10).pow(12).mul(100),
+      gas: Big(10).pow(14),
     });
   }
   if (mode == "Create" || mode == "Edit") {
@@ -200,8 +198,7 @@ const onSubmit = () => {
           predecessor_id: "${REPL_DEVHUB_CONTRACT}",
           keys: [context.accountId + "/index/notify"],
         },
-        deposit: Big(10).pow(23),
-        gas: Big(10).pow(12).mul(30),
+        gas: Big(10).pow(14),
       });
     }
     Near.call(txn);

--- a/src/devhub/entity/team/LabelRow.jsx
+++ b/src/devhub/entity/team/LabelRow.jsx
@@ -109,8 +109,7 @@ function editTeam({
               parents: [],
             },
           },
-          deposit: Big(0).pow(21),
-          gas: Big(10).pow(12).mul(100),
+          gas: Big(10).pow(14),
         });
       }
     });
@@ -140,8 +139,7 @@ function editTeam({
           parents: [],
         },
       },
-      deposit: Big(0).pow(21),
-      gas: Big(10).pow(12).mul(100),
+      gas: Big(10).pow(14),
     },
   ]);
 }

--- a/src/devhub/page/admin/index.jsx
+++ b/src/devhub/page/admin/index.jsx
@@ -70,8 +70,7 @@ function createEditTeam({
             parents: [],
           },
         },
-        deposit: Big(0).pow(21),
-        gas: Big(10).pow(12).mul(100),
+        gas: Big(10).pow(14),
       });
     }
   });
@@ -97,8 +96,7 @@ function createEditTeam({
           parents: [],
         },
       },
-      deposit: Big(0).pow(21),
-      gas: Big(10).pow(12).mul(100),
+      gas: Big(10).pow(14),
     },
   ]);
 }

--- a/src/devhub/page/create.jsx
+++ b/src/devhub/page/create.jsx
@@ -167,8 +167,7 @@ const onSubmit = () => {
         labels,
         body: body,
       },
-      deposit: Big(10).pow(21).mul(3),
-      gas: Big(10).pow(12).mul(100),
+      gas: Big(10).pow(14),
     });
   } else if (mode == "Edit") {
     txn.push({
@@ -179,8 +178,7 @@ const onSubmit = () => {
         labels,
         body: body,
       },
-      deposit: Big(10).pow(21).mul(2),
-      gas: Big(10).pow(12).mul(100),
+      gas: Big(10).pow(14),
     });
   }
   if (mode == "Create" || mode == "Edit") {
@@ -192,8 +190,7 @@ const onSubmit = () => {
           predecessor_id: "${REPL_DEVHUB_CONTRACT}",
           keys: [context.accountId + "/index/notify"],
         },
-        deposit: Big(10).pow(23),
-        gas: Big(10).pow(12).mul(30),
+        gas: Big(10).pow(14),
       });
     }
     Near.call(txn);


### PR DESCRIPTION
Resolves https://github.com/near/neardevhub-widgets/issues/549

This removes the deposit from all function calls to DevHub contract in our codebase, and set the gas for all of them to Big(10).pow(14) ([MAX_GAS](https://github.com/near/near-api-js/blob/858b8ee35ffc7d6409b3d72b01f59f4e117db613/packages/cookbook/utils/calculate-gas.js#L10))

[PREVIEW](https://test.near.social/devhub-dev.testnet/widget/app)